### PR TITLE
1.4.1

### DIFF
--- a/QuickPing/Patches/Minimap.cs
+++ b/QuickPing/Patches/Minimap.cs
@@ -149,7 +149,7 @@ namespace QuickPing.Patches
                             Minimap.instance.RemovePin(closestPin);
                         }
 
-                        Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
+                        pinData = Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
 
                         //INFO
                         QuickPingPlugin.Log.LogInfo($"Add Pin : Name:{pinData.m_name} x:{pinData.m_pos.x}, y:{pinData.m_pos.y}, Type:{pinData.m_type}");
@@ -158,7 +158,7 @@ namespace QuickPing.Patches
                 //OTHERS
                 else if (closestPin == null)
                 {
-                    Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
+                    pinData = Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
 
                     //INFO
                     QuickPingPlugin.Log.LogInfo($"Add Pin : Name:{pinData.m_name} x:{pinData.m_pos.x}, y:{pinData.m_pos.y}, Type:{pinData.m_type}");
@@ -177,7 +177,7 @@ namespace QuickPing.Patches
                         pinData.m_name = Settings.DefaultPingText;
                         break;
                 }
-                Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
+                pinData = Minimap.instance.AddPin(pinData.m_pos, pinData.m_type, pinData.m_name, true, false, 0L);
 
                 //INFO
                 QuickPingPlugin.Log.LogInfo($"Force Add Pin : Name:{pinData.m_name} x:{pos.x}, y:{pos.y}, Type:{pinData.m_type}");

--- a/QuickPing/Properties/AssemblyInfo.cs
+++ b/QuickPing/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 //JObject
-[assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4")]
+[assembly: AssemblyVersion("1.4.1")]
+[assembly: AssemblyFileVersion("1.4.1")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/QuickPing/QuickPing.cs
+++ b/QuickPing/QuickPing.cs
@@ -11,7 +11,7 @@ namespace QuickPing
     {
         public const string GUID = "com.atopy.plugins.quickping";
         public const string NAME = "QuickPing";
-        public const string VERSION = "1.0.4";
+        public const string VERSION = "1.4.1";
     }
     public enum HoverType
     {


### PR DESCRIPTION
Fixed a bug where forced pins were not removed when attached gameobject was destroyed (pinData not exact)